### PR TITLE
Resize into a square image.

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -15,7 +15,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE WORK.
 -->
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="481.8897pt" height="340.1574pt" viewBox="0 0 481.8897 340.1574" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="480pt" height="480pt" viewBox="0 -50 480 430" version="1.1">
 <defs>
 <clipPath id="clip1">
   <path d="M 0 340.15625 L 481.890625 340.15625 L 481.890625 0 L 0 0 L 0 340.15625 Z M 0 340.15625 "/>


### PR DESCRIPTION
This adjusts the logo image into a square so that GitHub would accept it as a profile picture.  [`haskell-actions.png`](https://user-images.githubusercontent.com/1133140/232511938-523dc5c4-867a-4974-b245-2f50438b2444.png) is the PNG version of this, previewed below.

![haskell-actions](https://user-images.githubusercontent.com/1133140/232511938-523dc5c4-867a-4974-b245-2f50438b2444.png)
